### PR TITLE
Subclassing and virtual pin reading problem

### DIFF
--- a/lib/client.py
+++ b/lib/client.py
@@ -13,7 +13,7 @@ import socket
 
 from . import common
 
-class TCP_Client():
+class TCP_Client(object):
 	_Server=None
 	_Port=None
 	_Socket=None

--- a/lib/client.py
+++ b/lib/client.py
@@ -103,7 +103,7 @@ class TCP_Client():
 				msg_type,
 				self.newMessageID(),
 				len(data)
-			)+data
+			)+data.encode('ascii')
 		)
 	
 	def newMessageID(self):

--- a/lib/hw.py
+++ b/lib/hw.py
@@ -10,7 +10,7 @@ __license__	= "MIT"
 
 from . import common
 
-class Hardware():
+class Hardware(object):
 	_Media=None
 	
 	def __init__(self,media):

--- a/lib/server/__init__.py
+++ b/lib/server/__init__.py
@@ -12,7 +12,7 @@ def createFromConf(conf,storage=None):
 	if conf['type']=='tcp':
 		return TCP_Server(conf['conf'],storage)
 	
-class Server():
+class Server(object):
 	conf=None
 	Storage=None
 	Connections=None

--- a/tools/inc/database/db_sqlite.py
+++ b/tools/inc/database/db_sqlite.py
@@ -20,6 +20,6 @@ def dict_factory(cursor, row):
 		d[col[0]] = row[idx]
 	return d
 
-class Database():
+class Database(object):
 	def __init__(self,conf):
 		pass


### PR DESCRIPTION
I propose those commits to solve two issues I faced : 
When overloading the **init** method of hw.Harware, the super() method failed because of old class style. So I've made some changes to use new ones. Hope I've not forget some of them.
The other issue was about concatenating string to bytes in client.py. I guess it's because of the recent changes you've made to conform to python3...
I hope this helps...
